### PR TITLE
zmiana adresów do komunikacji z sandbox allegro.pl

### DIFF
--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -6,7 +6,7 @@ class Sandbox extends Api
 
     const API_URI = 'https://sandbox.allegroapi.io';
 
-    const TOKEN_URI = 'https://ssl.allegro.pl.webapisandbox.pl/auth/oauth/token';
+    const TOKEN_URI = 'https://allegro.pl.allegrosandbox.pl/auth/oauth/token';
 
-    const AUTHORIZATION_URI = 'https://ssl.allegro.pl.webapisandbox.pl/auth/oauth/authorize';
+    const AUTHORIZATION_URI = 'https://allegro.pl.allegrosandbox.pl/auth/oauth/authorize';
 }


### PR DESCRIPTION
Allegro wprowadziło nowy serwer sandbox:  https://allegro.pl/webapi/news.php#news_100602
stare środowisko zostanie zamknięte 29 kwietnia.
W wyniku tej zmiany należy podmienić linki do autoryzacji na sandbox.